### PR TITLE
Fix #18: replace removed default LLM model with openai/gpt-oss-120b:nitro

### DIFF
--- a/src/features/chat/openAiChat.ts
+++ b/src/features/chat/openAiChat.ts
@@ -70,10 +70,16 @@ export async function getChatResponseStream(
             // "model": "openai/gpt-3.5-turbo",
             // "model": "cohere/command-r-plus",
             // "model": "anthropic/claude-3.5-sonnet:beta",
-            "model": "google/gemini-2.0-flash-exp:free",
+            // "model": "google/gemini-2.0-flash-exp:free", // removed from OpenRouter
+            "model": "openai/gpt-oss-120b:nitro",
+            // gpt-oss is a reasoning model and its reasoning tokens count against
+            // max_tokens. Keep reasoning effort low and give the reply some
+            // headroom so the spoken answer isn't truncated by the thinking budget.
+            // (reasoning tokens are filtered out of the stream below.)
+            "reasoning": { "effort": "low" },
             "messages": messages,
             "temperature": 0.7,
-            "max_tokens": 200,
+            "max_tokens": 512,
             "stream": true,
           })
         });
@@ -126,7 +132,11 @@ export async function getChatResponseStream(
                 messages.forEach((message) => {
                   const content = message.choices[0].delta.content;
 
-                  controller.enqueue(content);
+                  // Skip deltas without content (e.g. role-only or reasoning
+                  // deltas) so we don't enqueue undefined into the stream.
+                  if (content) {
+                    controller.enqueue(content);
+                  }
                 });
               } catch (error) {
                 // log the messages


### PR DESCRIPTION
## Problem

Fixes #18 ("No responces"). The default model `google/gemini-2.0-flash-exp:free` was **removed from OpenRouter** (confirmed against the live `/api/v1/models` list).

Failure chain: the chat request returns HTTP 400 with a JSON error body (not an SSE stream) → the parser in `openAiChat.ts` only looks for `data:` lines, finds none, enqueues nothing, and silently closes (`isStreamed` stays false). The user sees no response, matching the screenshot in the issue.

## Changes

`src/features/chat/openAiChat.ts`:
- **Default model → `openai/gpt-oss-120b:nitro`** (`:nitro` routes to the highest-throughput providers). Old default left as a comment noting why it was removed.
- **`reasoning: { effort: "low" }` + `max_tokens` raised 200 → 512.** gpt-oss is a reasoning model and its reasoning tokens count against `max_tokens`; without headroom the spoken reply could be truncated to empty (the same "no responses" symptom). Low effort keeps latency/cost down.
- **Skip deltas without `content`** in the stream parser, so role-only / reasoning / empty deltas never enqueue `undefined` into the TTS pipeline.

## Notes

- This model is **paid** but cheap (~$0.04 / 1M input, ~$0.18 / 1M output). Since the app ships with the maintainer's OpenRouter key by default, trial traffic draws credits. Free instruct alternatives exist (`meta-llama/llama-3.3-70b-instruct:free`, `qwen/qwen3-next-80b-a3b-instruct:free`) but free-tier uptime/rate-limits were unreliable for a default.
- Builds clean locally (`next build`, Next 13.2.4). Separately, the Vercel deploy needed the project's Node.js version bumped to a currently-supported release (done in project settings) — the prior deploy was 14 months old and pinned to a now-retired Node version, unrelated to this code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)